### PR TITLE
Battery Health Check. Typo and Grunt

### DIFF
--- a/app/javascript/nest.js
+++ b/app/javascript/nest.js
@@ -126,7 +126,7 @@ function listenForCOAlarms(alarm) {
 
 */
 function listenForBatteryAlarms(alarm) {
-  alarm.child('battry_health').ref().on('value', function (state) {
+  alarm.child('battery_health').ref().on('value', function (state) {
 
     // Don't show battery alerts if a more
     // important alert is already showing
@@ -134,7 +134,7 @@ function listenForBatteryAlarms(alarm) {
          alarm.smoke_alarm_state === 'ok' &&
          alarm.co_alarm_state === 'ok') {
       notify('Replace battery', {
-        tag: alarm.child('device_id').val() + '-battry_health',
+        tag: alarm.child('device_id').val() + '-battery_health',
         body: 'The battery is low on ' + alarm.child('name_long').val(),
         color: alarm.child('ui_color_state').val()
       });

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/nestlabs/alert-jquery.git"
+  },
+  "devDependencies": {
+    "grunt": "latest"
   }
 }


### PR DESCRIPTION
Fixed a spelling typo in the Battery Health Check: `battry_health` -> `battery_health`

Also, grunt should to be installed locally as per http://gruntjs.com/getting-started#how-the-cli-works so I've added it as a devDependency.